### PR TITLE
Fix handling of arguments to stash/stashApply

### DIFF
--- a/0.13/hoarder/src/main/sbt_0.13/org.romanowski.hoarder/core/HoarderEngine.scala
+++ b/0.13/hoarder/src/main/sbt_0.13/org.romanowski.hoarder/core/HoarderEngine.scala
@@ -8,7 +8,7 @@ package org.romanowski.hoarder.core
 
 import java.io.File
 import java.nio.charset.Charset
-import java.nio.file.Files
+import java.nio.file.{Files, Path}
 
 import sbt.compiler.{IC, MixedAnalyzingCompiler}
 import sbt.inc.MappableFormat
@@ -23,11 +23,14 @@ class HoarderEngine extends HoarderEngineCommon {
   type PreviousCompilationResult = Compiler.PreviousAnalysis
 
 
-  protected override def exportCacheTaskImpl(setup: CacheSetup, result: CompilationResult): Unit = {
+  protected override def exportCacheTaskImpl(setup: CacheSetup,
+                                             result: CompilationResult,
+                                             globalCacheLocation: Path): Unit = {
     import setup._
+    val cacheLocation = globalCacheLocation.resolve(relativeCacheLocation)
 
     if (Files.exists(cacheLocation)) {
-      if(overrideExistingCache) IO.delete(setup.cacheLocation.toFile)
+      if(overrideExistingCache) IO.delete(cacheLocation.toFile)
       else new IllegalArgumentException(s"Cache already exists at $cacheLocation.")
     }
 
@@ -50,8 +53,10 @@ class HoarderEngine extends HoarderEngineCommon {
     IO.zip(classesToZip, cacheLocation.resolve(classesZipFileName).toFile)
   }
 
-  protected override def importCacheTaskImpl(cacheSetup: CacheSetup): Option[PreviousCompilationResult] = {
+  protected override def importCacheTaskImpl(cacheSetup: CacheSetup,
+                                             globalCacheLocation: Path): Option[PreviousCompilationResult] = {
     import cacheSetup._
+    val cacheLocation = globalCacheLocation.resolve(relativeCacheLocation)
 
     val from = cacheLocation.resolve(analysisCacheFileName)
     val classesZip = cacheLocation.resolve(classesZipFileName)

--- a/0.13/hoarder/src/main/scala/org/romanowski/HoarderCommonSettings.scala
+++ b/0.13/hoarder/src/main/scala/org/romanowski/HoarderCommonSettings.scala
@@ -6,7 +6,7 @@
 
 package org.romanowski
 
-import java.nio.file.Path
+import java.nio.file.{Files, Path}
 
 import org.romanowski.hoarder.core._
 import sbt._
@@ -14,11 +14,32 @@ import sbt._
 
 object HoarderCommonSettings {
   val globalCacheLocation = InputKey[Path]("cacheLocation", "Location for cache for given project.")
+  private[romanowski] val globalCacheLocationScoped =
+    InputKey[Path]("cacheLocationScoped", "Location for cache for given project.")
+
   val staticCacheLocation = TaskKey[Path]("staticCacheLocation", "Location for cache for given project.")
   val cleanOutputMode = SettingKey[CleanOutputMode]("cleanOutputMode", "What should be cleaned prior to cache extraction")
-  val overrideExistingCache = SettingKey[Boolean]("Override existing stash")
+  val overrideExistingCache = SettingKey[Boolean]("overrideExistingCache", "Override existing stash")
 
-  val defaults = Seq(cleanOutputMode := CleanClasses, overrideExistingCache := false)
+  def defaultsGlobal =
+    Seq(
+      cleanOutputMode := CleanClasses,
+      overrideExistingCache := false,
+      globalCacheLocationScoped.in(ImportConfig) := {
+        val globalCache = globalCacheLocation.evaluated
+        assert(Files.isDirectory(globalCache) && Files.exists(globalCache),
+          s"Cache does not exists in $globalCache (${new File(".").getAbsolutePath}!")
+        globalCache
+      },
+      globalCacheLocationScoped.in(ExportConfig) := {
+        val globalCache = globalCacheLocation.evaluated
+        assert(!Files.exists(globalCache) || overrideExistingCache.value, s"Cache already exists in $globalCache!")
+        globalCache
+      }
+    )
+
+  val ImportConfig = config("cacheImport")
+  val ExportConfig = config("cacheExport")
 }
 
 

--- a/0.13/hoarder/src/main/scala/org/romanowski/HoarderPlugin.scala
+++ b/0.13/hoarder/src/main/scala/org/romanowski/HoarderPlugin.scala
@@ -12,7 +12,11 @@ import sbt.{AllRequirements, AutoPlugin, PluginTrigger}
 
 
 object HoarderPlugin extends AutoPlugin {
-  override def projectSettings = HoarderCommonSettings.defaults ++ Stash.settings ++ StaticInteractiveLocation.settings
+  import HoarderCommonSettings._
+
+  override def projectSettings = Stash.settings
+
+  override def globalSettings: Seq[_root_.sbt.Def.Setting[_]] = StaticInteractiveLocation.settings ++ defaultsGlobal
 
   override def trigger: PluginTrigger = AllRequirements
 }

--- a/0.13/hoarder/src/main/scala/org/romanowski/hoarder/actions/NaiveAutoimport.scala
+++ b/0.13/hoarder/src/main/scala/org/romanowski/hoarder/actions/NaiveAutoimport.scala
@@ -24,7 +24,7 @@ class NaiveAutoimport extends HoarderEngine {
     val location = staticCacheLocation.value
     val result = compileIncremental.value
 
-    exportCacheTaskImpl(projectSetupFor.value(location), result)
+    exportCacheTaskImpl(projectSetupFor.value, result, location)
     streams.value.log.info(s"Cache exported tp $location")
 
     location
@@ -34,7 +34,7 @@ class NaiveAutoimport extends HoarderEngine {
     val location = staticCacheLocation.value
     streams.value.log.info(s"Importing cache from: $location")
 
-    val res = importCacheTaskImpl(projectSetupFor.value(location))
+    val res = importCacheTaskImpl(projectSetupFor.value, location)
       .getOrElse(previousCompile.value)
 
     streams.value.log.info(s"Done")

--- a/0.13/hoarder/src/main/scala/org/romanowski/hoarder/core/HoarderEngineCommon.scala
+++ b/0.13/hoarder/src/main/scala/org/romanowski/hoarder/core/HoarderEngineCommon.scala
@@ -10,7 +10,7 @@ import java.nio.charset.Charset
 
 import sbt._
 import sbt.Keys._
-import java.nio.file.Path
+import java.nio.file.{Path, Paths}
 
 import org.romanowski.HoarderCommonSettings._
 
@@ -26,28 +26,25 @@ trait HoarderEngineCommon {
                         classesRoot: Path,
                         projectRoot: Path,
                         analysisFile: File,
-                        cacheLocation: Path,
+                        relativeCacheLocation: Path,
                         overrideExistingCache: Boolean,
                         cleanOutputMode: CleanOutputMode
                        )
 
-  protected def exportCacheTaskImpl(setup: CacheSetup, result: CompilationResult): Unit
+  protected def exportCacheTaskImpl(setup: CacheSetup, result: CompilationResult, globalCacheLocation: Path): Unit
 
-  protected def importCacheTaskImpl(cacheSetup: CacheSetup): Option[PreviousCompilationResult]
+  protected def importCacheTaskImpl(cacheSetup: CacheSetup, globalCacheLocation: Path): Option[PreviousCompilationResult]
 
-  protected def projectSetupFor = Def.task[Path => CacheSetup] {
-    path => {
+  protected def projectSetupFor = Def.task[CacheSetup] {
       CacheSetup(
         sourceRoots = managedSourceDirectories.value ++ unmanagedSourceDirectories.value,
         classpath = externalDependencyClasspath.value,
         classesRoot = classDirectory.value.toPath,
         projectRoot = baseDirectory.value.toPath,
         analysisFile = (streams in compileIncSetup).value.cacheDirectory / compileAnalysisFilename.value,
-        cacheLocation = path.resolve(name.value).resolve(configuration.value.name),
+        relativeCacheLocation = Paths.get(name.value).resolve(configuration.value.name),
         overrideExistingCache = overrideExistingCache.value,
         cleanOutputMode = cleanOutputMode.value
       )
     }
-  }
-
 }

--- a/0.13/hoarder/src/main/scala/org/romanowski/hoarder/location/StaticInteractiveLocation.scala
+++ b/0.13/hoarder/src/main/scala/org/romanowski/hoarder/location/StaticInteractiveLocation.scala
@@ -16,21 +16,26 @@ object StaticInteractiveLocation {
   val globalLabel = SettingKey[String]("Default label for project")
   val globalStashLocation = TaskKey[File]("globalStashLocation", "Place where stashed artifacts are kept")
 
-  val parser = spaceDelimited("<export-label>")
+  val parser = {
+    import sbt.complete.Parser._
+    import sbt.complete.Parsers._
+
+    Space.* ~> token(StringBasic, "Project label").?
+      .flatMap { res =>
+        (Space.+ ~> token(StringBasic, "Version label")).?.map(res -> _)
+      } <~ Space.*
+  }
+
 
   private def configName = Def.task {
     (configuration in ThisScope).?.value.map(_.name).getOrElse("unknown")
   }
 
   private def askForStashLocation = Def.inputTask {
-    val args = parser.parsed
+    val (providedLabel, providedVersion) = parser.parsed
 
-    val (currentGlobalLabel, currentLocalLabel) = args match {
-      case Nil => (globalLabel.value, defaultVersionLabel.value)
-      case Seq(label) => (label, defaultVersionLabel.value)
-      case Seq(global, local) => (global, local)
-      case _ => throw new IllegalArgumentException("Only one args is required!") // TODO add proper parser!
-    }
+    val currentGlobalLabel = providedLabel.getOrElse(globalLabel.value)
+    val currentLocalLabel = providedVersion.getOrElse(defaultVersionLabel.value)
 
     val file = globalStashLocation.value / currentGlobalLabel / currentLocalLabel
     file.toPath
@@ -39,7 +44,7 @@ object StaticInteractiveLocation {
   val settings = Seq(
     defaultVersionLabel := "HEAD",
     globalLabel := file(".").getAbsoluteFile.getParentFile.getName,
-    globalStashLocation := dependencyCacheDirectory.value / ".." / "sbt-stash",
+    globalStashLocation := BuildPaths.getGlobalBase(state.value) / "sbt-stash",
     staticCacheLocation := globalCacheLocation.toTask("").value,
     globalCacheLocation := askForStashLocation.evaluated
   )

--- a/0.13/hoarder/src/test/scala/org/romanowski/hoarder/location/StaticInteractiveLocationTets.scala
+++ b/0.13/hoarder/src/test/scala/org/romanowski/hoarder/location/StaticInteractiveLocationTets.scala
@@ -1,0 +1,46 @@
+/*
+ * Hoarder - Cached compilation plugin for sbt.
+ * Copyright 2016 - 2017, Krzysztof Romanowski
+ * This software is released under the terms written in LICENSE.
+ */
+
+package org.romanowski.hoarder.location
+
+import org.scalatest.{FlatSpec, Matchers}
+import sbt.complete.{DefaultParsers, Parser}
+import sbt.complete.Parser.Value
+
+class StaticInteractiveLocationTests extends FlatSpec with Matchers {
+
+  implicit class ParserOps[T](opts: Parser[T]) {
+    def successful(input: String): T = {
+      DefaultParsers(opts)(input).resultEmpty match {
+        case Value(v) =>
+          v
+        case failure =>
+          fail(s"Input '$input' parsed with following errors: ${failure.errors}")
+      }
+    }
+
+    def failed(input: String) =  DefaultParsers(opts)(input).resultEmpty shouldBe a[Parser.Failure]
+  }
+
+  behavior of "Parser"
+
+  it should "Parse correctly" in {
+    StaticInteractiveLocation.parser.successful("") shouldEqual (None, None)
+    StaticInteractiveLocation.parser.successful(" ") shouldEqual (None, None)
+    StaticInteractiveLocation.parser.successful("  ") shouldEqual (None, None)
+    StaticInteractiveLocation.parser.successful("ala ola") shouldEqual (Some("ala"), Some("ola"))
+    StaticInteractiveLocation.parser.successful("ala    ola") shouldEqual (Some("ala"), Some("ola"))
+    StaticInteractiveLocation.parser.successful("  ala    ola") shouldEqual (Some("ala"), Some("ola"))
+    StaticInteractiveLocation.parser.successful("ala") shouldEqual (Some("ala"), None)
+    StaticInteractiveLocation.parser.successful(" ala") shouldEqual (Some("ala"), None)
+    StaticInteractiveLocation.parser.successful(" ala    ") shouldEqual (Some("ala"), None)
+    StaticInteractiveLocation.parser.successful("ala    ") shouldEqual (Some("ala"), None)
+
+
+    StaticInteractiveLocation.parser.failed("ala ula ola")
+    StaticInteractiveLocation.parser.failed("ala\tula\tola")
+  }
+}

--- a/0.13/hoarderTests/build.sbt
+++ b/0.13/hoarderTests/build.sbt
@@ -13,7 +13,6 @@ ScriptedPlugin.scriptedSettings
 scriptedLaunchOpts := { scriptedLaunchOpts.value ++
   Seq(
     "-Xmx1024M",
-    "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5015",
     "-Dplugin.version=" + version.value
 
   )

--- a/0.13/hoarderTests/src/sbt-test/singleProject/export-cache/test
+++ b/0.13/hoarderTests/src/sbt-test/singleProject/export-cache/test
@@ -1,4 +1,3 @@
-> test:compile
 > stash
 $ touch .cached-compilation
 > clean

--- a/0.13/hoarderTests/src/sbt-test/singleProject/labelsTests/build.sbt
+++ b/0.13/hoarderTests/src/sbt-test/singleProject/labelsTests/build.sbt
@@ -1,0 +1,1 @@
+org.romanowski.hoarder.tests.PluginTests.testRecompilation

--- a/0.13/hoarderTests/src/sbt-test/singleProject/labelsTests/project/plugins.sbt
+++ b/0.13/hoarderTests/src/sbt-test/singleProject/labelsTests/project/plugins.sbt
@@ -1,0 +1,10 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                 |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else {
+    addSbtPlugin("org.romanowski" % "hoarder" % pluginVersion)
+    addSbtPlugin("org.romanowski" % "hoarder-tests" % pluginVersion)
+  }
+}

--- a/0.13/hoarderTests/src/sbt-test/singleProject/labelsTests/src/main/scala/Test.scala
+++ b/0.13/hoarderTests/src/sbt-test/singleProject/labelsTests/src/main/scala/Test.scala
@@ -1,0 +1,13 @@
+/*
+ * Hoarder - Cached compilation plugin for sbt.
+ * Copyright 2016 - 2017, Krzysztof Romanowski
+ * This software is released under the terms written in LICENSE.
+ */
+
+class Test {
+
+}
+
+object MyApp extends App {
+  println("working!")
+}

--- a/0.13/hoarderTests/src/sbt-test/singleProject/labelsTests/src/test/scala/MyTestClass.scala
+++ b/0.13/hoarderTests/src/sbt-test/singleProject/labelsTests/src/test/scala/MyTestClass.scala
@@ -1,0 +1,7 @@
+/*
+ * Hoarder - Cached compilation plugin for sbt.
+ * Copyright 2016 - 2017, Krzysztof Romanowski
+ * This software is released under the terms written in LICENSE.
+ */
+
+class MyTestClass

--- a/0.13/hoarderTests/src/sbt-test/singleProject/labelsTests/test
+++ b/0.13/hoarderTests/src/sbt-test/singleProject/labelsTests/test
@@ -1,0 +1,28 @@
+$ mkdir global/sbt-stash/fakeProject/fakeVersion
+-> "stashApply p1 v1"
+-> "stashApply fakeProject fakeVersion2"
+-> "stashApply fakeProject"
+> clean
+> "stash p1 v1"
+$ touch .cached-compilation
+$ touch .cached-compilation-done
+> clean
+> "stashApply fakeProject fakeVersion"
+-> testCacheImport
+> clean
+> "stashApply p1 v1"
+> testCacheImport
+-> "stashApply p1 v1 too-much!"
+> clean
+# Test applying non-existing caches
+-> "stashApply p1"
+> clean
+-> "stashApply failed failed2"
+> clean
+# Test stash with overrides
+$ delete .cached-compilation
+$ delete .cached-compilation-done
+-> "stash p1 v1"
+> "stash p1 v2"
+> "set org.romanowski.HoarderCommonSettings.overrideExistingCache.in(Global) := true"
+> "stash p1 v1"

--- a/0.13/hoarderTests/src/sbt-test/singleProject/multiProjectCache/test
+++ b/0.13/hoarderTests/src/sbt-test/singleProject/multiProjectCache/test
@@ -1,4 +1,3 @@
-> test:compile
 > stash
 $ touch .cached-compilation
 > clean

--- a/1.0/src/main/sbt_1.0/org.romanowski.hoarder/core/HoarderEngine.scala
+++ b/1.0/src/main/sbt_1.0/org.romanowski.hoarder/core/HoarderEngine.scala
@@ -22,7 +22,10 @@ class HoarderEngine extends HoarderEngineCommon {
   type CompilationResult = xsbti.compile.CompileResult
   type PreviousCompilationResult = xsbti.compile.PreviousResult
 
-  protected override def exportCacheTaskImpl(setup: CacheSetup, result: CompilationResult): Unit = {}
+  protected override def exportCacheTaskImpl(setup: CacheSetup,
+                                             result: CompilationResult,
+                                             globalCacheLocation: Path): Unit = {}
 
-  protected override def importCacheTaskImpl(cacheSetup: CacheSetup): Option[PreviousCompilationResult] = None
+  protected override def importCacheTaskImpl(cacheSetup: CacheSetup,
+                                             globalCacheLocation: Path): Option[PreviousCompilationResult] = None
 }


### PR DESCRIPTION
Now we call setup in each scope and based on that call stash/stashApply implementation (so arguments are evaluated only once).