### PR TITLE
Add documentation for gitlab-ci stash workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Hoarder can be used in your project in multiple ways (workflows) described below
 Stash workflow allows you to stash compilation results similarly to changes in git.
 Running `stash` task will store your current compilation data in a global directory for your project and later you can import that compilation using `stashApply` command. More can be found in [docs](docs/stash.md).
 
+The stash workflow can be useful to avoid recompilation in
+a [gitlab-ci](docs/gitlab-ci.md) pipeline.
+
 ### [Cached PR verfication builds (e.g. Travis ones)](docs/stash.md)
 
 This workflow main goal is speed up of PR verification builds incrementally recompiling changes in PR. 

--- a/docs/gitlab-ci.md
+++ b/docs/gitlab-ci.md
@@ -4,13 +4,15 @@ It is possible to use the stash workflow to avoid recompiling sources multiple
 times in a single gitlab-ci pipeline.  For instance if you have different jobs
 in the your pipeline which run different variations of `sbt test`.
 
+`sbt-hoarder` works largely out of the box.
 For convenience if you have a multi-project build, you may wish to change
-the default stash directory to be at the top level of your project:
+the default stash directory to be at the top level of your project like this:
 ```
 globalStashLocation := (baseDirectory in ThisBuild).value / "sbt-stash"
 ```
 
-Example `gitlab-ci.yaml`:
+Then you should use `artifacts:` and `dependencies:` as in the following
+example `gitlab-ci.yaml`:
 
 ```
 stages:
@@ -38,7 +40,7 @@ slow-integration-test-two:
   dependencies:
     - unit-test
   script:
-    - sbt stashApply 'IntegrtionTestTwo/test'
+    - sbt stashApply 'IntegrationTestTwo/test'
 ```
 
 ## Use `artifacts:` not `cache:`
@@ -59,6 +61,8 @@ None of this is an issue if you use `artifacts:` as in the example above.
 external dependencies.  You could cache your `~/.ivy` directory.)
 
 ## Alternatives
+
+You may not need sbt-hoarder at all:
 
 - Simplest is to combine all your sbt tasks into one gitlab-ci
   job.  Then no caching is required.

--- a/docs/gitlab-ci.md
+++ b/docs/gitlab-ci.md
@@ -1,0 +1,67 @@
+# Stash and gitlab-ci
+
+It is possible to use the stash workflow to avoid recompiling sources multiple
+times in a single gitlab-ci pipeline.  For instance if you have different jobs
+in the your pipeline which run different variations of `sbt test`.
+
+For convenience if you have a multi-project build, you may wish to change
+the default stash directory to be at the top level of your project:
+```
+globalStashLocation := (baseDirectory in ThisBuild).value / "sbt-stash"
+```
+
+Example `gitlab-ci.yaml`:
+
+```
+stages:
+  - quick
+  - slow
+
+unit-test:
+  stage: quick
+  artifacts:
+    paths:
+      - sbt-stash
+    expire_in: 1 day
+  script:
+    - sbt clean test:compile stash Common/test
+
+slow-integration-test-one:
+  stage: slow
+  dependencies:
+    - unit-test
+  script:
+    - sbt stashApply 'IntegrationTestOne/test'
+
+slow-integration-test-two:
+  stage: slow
+  dependencies:
+    - unit-test
+  script:
+    - sbt stashApply 'IntegrtionTestTwo/test'
+```
+
+## Use `artifacts:` not `cache:`
+
+Gitlab `cache` at best provided on a "best effort" basis, and in any case is only
+cached per-runner, so in the presence of multiple runners it will be unlikely
+to be available for later jobs.  When using `cache` also beware that the runner
+logs say cache was found even when no files were actually provided (for instance
+because the cache is on a different runner)
+
+Even in a single runner setup, "best effort" combines badly with `sbt-hoarder`'s stash
+workflow: `sbt stashApply` will fail if a stash is not found rather than silently
+succeeding without using a stash.  This would generally cause your pipeline to fail.
+
+None of this is an issue if you use `artifacts:` as in the example above. 
+
+(A valid related use of `cache` is to avoid re-downloading
+external dependencies.  You could cache your `~/.ivy` directory.)
+
+## Alternatives
+
+- Simplest is to combine all your sbt tasks into one gitlab-ci
+  job.  Then no caching is required.
+  
+- You can also avoid recompilation by having your compilation job
+  publish its jar to a repository such as Nexus.

--- a/docs/stash.md
+++ b/docs/stash.md
@@ -36,6 +36,6 @@ Loading cached results needs to clean up previous compilation (if exsist) and by
 
 ### Cleaning stashed compilation: `stashClean` task
 
-`stashApply [<projectLabel> [<versionLabel>]]`
+`stashClean [<projectLabel> [<versionLabel>]]`
 
 This task will clean cached compilation under given labels. Implemented for @mfedortsov. 


### PR DESCRIPTION
- adds a gitlab-ci specific doc with example `gitlab-ci.yaml` file
- add link from top level `README.md`
- fix typo